### PR TITLE
Add PAGES_TO_GET to config.py

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,4 +1,4 @@
 BEE_API_KEY = ""
 BEE_API_ENDPOINT = "https://api.bee.computer/v1"
-
+PAGES_TO_GET = ""
 TARGET_DIR = "/Users/brucebookman/bruce_vault/Conversations/bee"


### PR DESCRIPTION
`config.py` is missing the key `PAGES_TO_GET` and `app.py` errors out